### PR TITLE
Pass vmin and vmax inside norm

### DIFF
--- a/hclust2.py
+++ b/hclust2.py
@@ -679,9 +679,7 @@ class Heatmap:
                                 interpolation = 'nearest',  aspect='auto',
                                 extent = [0, self.nf, 0, self.ns],
                                 cmap=cm,
-                                vmin=self.args.minv,
-                                vmax=self.args.maxv,
-                                norm = norm_f( vmin=minv if minv > 0.0 else None, vmax=maxv)
+                                norm = norm_f( vmin=self.args.minv if self.args.minv > 0.0 else None, vmax=self.args.maxv)
                                 )
 
         #ax_hm.set_ylim([0,800])


### PR DESCRIPTION
Since matplotlib 3.3 passing vmin (--minv) and vmax (--maxv) simultaneously with norm is deprecated. This PR proposes passing vmin/vmax within norm.

Basically, I bumped into the following while running hclust2.py in a new conda env (matplotlib=3.6.2).
```
ValueError: Passing a Normalize instance simultaneously with vmin/vmax is not supported. Please pass vmin/vmax directly to the norm when creating it.
```
Then noticed a few people recently faced the same issue, as reported [here](https://forum.biobakery.org/t/hclust2-valueerror-passing-a-normalize-instance-simultaneously-with-vmin-vmax-is-not-supported-please-pass-vmin-vmax-directly-to-the-norm-when-creating-it/4473), [here](https://github.com/SegataLab/hclust2/issues/8) (closes #8) , and [here](https://github.com/SegataLab/hclust2/issues/3#issuecomment-1266095186). This simple fix did the job for me.

Thanks